### PR TITLE
Use baseColour option that’s already used in Default theme

### DIFF
--- a/PragmaThemePlugin.inc.php
+++ b/PragmaThemePlugin.inc.php
@@ -19,22 +19,21 @@ class PragmaThemePlugin extends ThemePlugin {
 	public function init() {
 		/* Additional theme options */
 		// Change theme primary color
-		$this->addOption('primaryColor', 'colour', array(
-			'label' => 'plugins.themes.pragma.option.primaryColor.label',
-			'description' => 'plugins.themes.pragma.option.primaryColor.description',
+		$this->addOption('baseColour', 'colour', array(
+			'label' => 'plugins.themes.default.option.colour.label',
 			'default' => '#A8DCDD',
 		));
 
-		$primaryColor = $this->getOption('primaryColor');
+		$baseColour = $this->getOption('baseColour');
 
 		$additionalLessVariables = [];
-		if ($primaryColor !== '#A8DCDD') {
-			$additionalLessVariables[] = '@primary-colour:' . $primaryColor . ';';
+		if ($baseColour !== '#A8DCDD') {
+			$additionalLessVariables[] = '@primary-colour:' . $baseColour . ';';
 			$additionalLessVariables[] = '@secondary-colour: darken(@primary-colour, 50%);';
 		}
 
 		// Update contrast colour based on primary colour
-		if ($this->isColourDark($this->getOption('primaryColor'))) {
+		if ($this->isColourDark($this->getOption('baseColour'))) {
 			$additionalLessVariables[] = '
 				@contrast-colour: rgba(255, 255, 255, 0.95);
 				@secondary-contrast-colour: rgba(255, 255, 255, 0.75);
@@ -96,7 +95,7 @@ class PragmaThemePlugin extends ThemePlugin {
 
 		$request = $this->getRequest();
 		$journal = $request->getJournal();
-		$primaryColor = $this->getOption('primaryColor');
+		$baseColour = $this->getOption('baseColour');
 
 		if (!defined('SESSION_DISABLE_INIT')) {
 
@@ -123,7 +122,7 @@ class PragmaThemePlugin extends ThemePlugin {
 				'languageToggleLocales' => $locales,
 				'loginUrl' => $loginUrl,
 				'orcidImageUrl' => $orcidImageUrl,
-				'primaryColor' => $primaryColor,
+				'baseColour' => $baseColour,
 			));
 		}
 	}

--- a/resources/less/components/article.less
+++ b/resources/less/components/article.less
@@ -15,7 +15,7 @@
 
 .article__title {
 	margin: 0 0 0.25em 0;
-	font-family: 'Alegreya', serif;
+	font-family: @font-family-primary;
 	font-weight: 400;
 }
 

--- a/resources/less/components/header.less
+++ b/resources/less/components/header.less
@@ -75,6 +75,11 @@
 	letter-spacing: normal;
 	font-family: @font-family-secondary;
 	font-weight: 700;
+
+	img {
+		max-height: 35px;
+		width: auto;
+	}
 }
 
 .main-menu__nav {

--- a/templates/frontend/pages/indexJournal.tpl
+++ b/templates/frontend/pages/indexJournal.tpl
@@ -24,7 +24,7 @@
 	{if $journalDescription or $announcements}
 	<header class="row">
 		{if $homepageImage}
-		<figure style="background-color: {$primaryColor};">
+		<figure style="background-color: {$baseColour};">
 			<img src="{$publicFilesDir}/{$homepageImage.uploadName|escape:'url'}"
 					 class="img-fluid"
 					 style="mix-blend-mode: luminosity;"


### PR DESCRIPTION
Trying to harmonise the variables we use -- Default’s `baseColour` already has a label and corresponds to the same concept. 