### PR TITLE
remove merge-stream in gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,6 @@ var concat = require('gulp-concat');
 var minifyCSS = require('gulp-csso');
 var sourcemaps = require('gulp-sourcemaps');
 var minify = require('gulp-minify');
-var merge = require('merge-stream');
 
 gulp.task('sass', function() {
 	return gulp


### PR DESCRIPTION
Remove reference to merge-stream dependency, which was partially removed from dev dependencies in https://github.com/pkp/pragma/commit/db0740f9b0141e45654e98139759024a2a9890e4