### PR TITLE
Create headerHead.tpl

### DIFF
--- a/templates/frontend/components/headerHead.tpl
+++ b/templates/frontend/components/headerHead.tpl
@@ -1,0 +1,26 @@
+{**
+ * templates/frontend/components/headerHead.tpl
+ *
+ * Copyright (c) 2014-2021 Simon Fraser University
+ * Copyright (c) 2000-2021 John Willinsky
+ * Distributed under the GNU GPL v3. For full terms see the file docs/COPYING.
+ *
+ * Common site header <head> tag and contents.
+ *}
+<head>
+	<meta charset="{$defaultCharset|escape}">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title>
+		{$pageTitleTranslated|strip_tags}
+		{* Add the journal name to the end of page titles *}
+		{if $requestedPage|escape|default:"index" != 'index' && $currentContext && $currentContext->getLocalizedName()}
+			| {$currentContext->getLocalizedName()}
+		{/if}
+	</title>
+
+	{load_header context="frontend"}
+	{load_stylesheet context="frontend"}
+	
+	{* Канонічні посилання для Google *}
+	<link rel="canonical" href="https://jrnls.ivet.edu.ua{$smarty.server.REQUEST_URI|escape}">
+</head>


### PR DESCRIPTION
The technical update to the headerHead.tpl file was implemented to resolve systemic indexing issues within Google Search Console by introducing a dynamic canonical tag.

Due to the internal architecture of Open Journal Systems (OJS), a single scientific article is often accessible through multiple URLs—such as versions with /uk/ or /en/ language prefixes, or legacy links containing index.php. Without a clear instruction, Google perceives these as duplicate content, which leads to indexing errors and splits the search ranking (authority) across multiple addresses. By adding specialized Smarty code to this template, every page now automatically declares its single, authoritative URL to search engines.

This ensures that Google consolidates all ranking signals and metadata onto one primary link, effectively eliminating "Duplicate without user-selected canonical" warnings. Ultimately, this fix stabilizes the journal’s presence in search results, prevents the dilution of SEO value, and ensures the platform meets the rigorous technical standards required by international scholarly databases.